### PR TITLE
Switch to api v2 endpoints

### DIFF
--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -1,4 +1,5 @@
 require 'omniauth-oauth'
+require 'multi_json'
 
 module OmniAuth
   module Strategies
@@ -29,9 +30,8 @@ module OmniAuth
 
       def raw_info
         @raw_info ||= begin
-                        debugger
-                        ri = MultiJson.decode(access_token.get('/api/2.0/user').body)
-                        emails = MultiJson.decode(access_token.get('/api/2.0/user/emails').body)
+                        ri = ::MultiJson.decode(access_token.get('/api/2.0/user').body)
+                        emails = ::MultiJson.decode(access_token.get('/api/2.0/user/emails').body)
                         email_hash = emails['values'].find { |email| email['is_primary'] && email['type'] == 'email' }
                         ri.merge('email' => email_hash['email'])
                       end

--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -21,17 +21,18 @@ module OmniAuth
 
       info do
         {
-          :name => "#{raw_info['first_name']} #{raw_info['last_name']}",
-          :avatar => raw_info['avatar'],
+          :name => raw_info['nickname'],
+          :avatar => raw_info['links']['avatar']['href'],
           :email => raw_info['email']
         }
       end
 
       def raw_info
         @raw_info ||= begin
-                        ri = MultiJson.decode(access_token.get('/api/1.0/user').body)['user']
-                        emails = MultiJson.decode(access_token.get('/api/1.0/emails').body)
-                        email_hash = emails.find { |email| email['primary'] } || emails.first || {}
+                        debugger
+                        ri = MultiJson.decode(access_token.get('/api/2.0/user').body)
+                        emails = MultiJson.decode(access_token.get('/api/2.0/user/emails').body)
+                        email_hash = emails['values'].find { |email| email['is_primary'] && email['type'] == 'email' }
                         ri.merge('email' => email_hash['email'])
                       end
       end

--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -33,7 +33,11 @@ module OmniAuth
                         ri = ::MultiJson.decode(access_token.get('/api/2.0/user').body)
                         emails = ::MultiJson.decode(access_token.get('/api/2.0/user/emails').body)
                         email_hash = emails['values'].find { |email| email['is_primary'] && email['type'] == 'email' }
-                        ri.merge('email' => email_hash['email'])
+                        if email_hash
+                          ri.merge('email' => email_hash['email'])
+                        else
+                          ri
+                        end
                       end
       end
     end

--- a/spec/omniauth/strategies/bitbucket_spec.rb
+++ b/spec/omniauth/strategies/bitbucket_spec.rb
@@ -7,7 +7,7 @@ describe OmniAuth::Strategies::Bitbucket do
     
     it 'should fall back to non-primary' do
       strategy.stub_chain(:access_token, :get) do |url|
-        body = url =~ /emails$/ ? %{[{"active": true, "email": "#{email}", "primary": false}]} : '{"user": {}}'
+        body = url =~ /emails$/ ? %{{"pagelen": 10, "values": [{"is_primary": true, "is_confirmed": true, "type": "email", "email": "#{email}", "links": {"self": {"href": "https://bitbucket.org/!api/2.0/user/emails/#{email}"}}}], "page": 1, "size": 1}} : '{"user": {}}'
         double body: body
       end
       strategy.raw_info['email'].should == email
@@ -15,7 +15,7 @@ describe OmniAuth::Strategies::Bitbucket do
   
     it "should prefer primary" do
       strategy.stub_chain(:access_token, :get) do |url|
-        body = url =~ /emails$/ ? %{[{"active": true, "email": "someemail@example.com", "primary": false}, {"active": true, "email": "#{email}", "primary": true}]} : '{"user": {}}'
+        body = url =~ /emails$/ ? %{{"pagelen": 10, "values": [{"is_primary": true, "is_confirmed": true, "type": "email", "email": "#{email}", "links": {"self": {"href": "https://bitbucket.org/!api/2.0/user/emails/#{email}"}}}], "page": 1, "size": 1}} : '{"user": {}}'
         double body: body
       end
       strategy.raw_info['email'].should == email
@@ -23,7 +23,7 @@ describe OmniAuth::Strategies::Bitbucket do
     
     it "should ignore non-existing" do
       strategy.stub_chain(:access_token, :get) do |url|
-        body = url =~ /emails$/ ? %{[]} : '{"user": {}}'
+        body = url =~ /emails$/ ? %{{"pagelen": 0, "values": []}} : '{"user": {}}'
         double body: body
       end
       strategy.raw_info['email'].should be_nil


### PR DESCRIPTION
Currently users cannot sign in/up with bitbucket because the end point has been deprecated. This PR introduces the first changes to point to API v2 but we probably also should update to Oauth2 and on top of this